### PR TITLE
Add batch execution, dynamic expansion to @petriflow/engine

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@petriflow/engine",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/engine/src/batch.test.ts
+++ b/packages/engine/src/batch.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { defineWorkflow } from "./workflow.js";
+import { createExecutor } from "./executor.js";
+import { Scheduler } from "./scheduler.js";
+import { sqliteAdapter } from "./persistence/sqlite-adapter.js";
+
+describe("stepBatch", () => {
+  it("fires independent transitions concurrently", async () => {
+    // Two independent branches: start splits into two parallel paths
+    type Place = "start" | "a_ready" | "b_ready" | "a_done" | "b_done";
+    type Ctx = { log: string[] };
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "parallel-test",
+      places: ["start", "a_ready", "b_ready", "a_done", "b_done"],
+      transitions: [
+        {
+          name: "split",
+          type: "automatic",
+          inputs: ["start"],
+          outputs: ["a_ready", "b_ready"],
+          guard: null,
+        },
+        {
+          name: "do_a",
+          type: "automatic",
+          inputs: ["a_ready"],
+          outputs: ["a_done"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "a"] }),
+        },
+        {
+          name: "do_b",
+          type: "automatic",
+          inputs: ["b_ready"],
+          outputs: ["b_done"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "b"] }),
+        },
+      ],
+      initialMarking: { start: 0, a_ready: 1, b_ready: 1, a_done: 0, b_done: 0 },
+      initialContext: { log: [] },
+      terminalPlaces: ["a_done", "b_done"],
+    });
+
+    const executor = createExecutor(def);
+    const result = await executor.stepBatch(
+      "inst-1",
+      { start: 0, a_ready: 1, b_ready: 1, a_done: 0, b_done: 0 },
+      { log: [] },
+      10,
+    );
+
+    expect(result.kind).toBe("fired");
+    if (result.kind === "fired") {
+      expect(result.transitions).toHaveLength(2);
+      expect(result.transitions).toContain("do_a");
+      expect(result.transitions).toContain("do_b");
+      expect(result.marking.a_done).toBe(1);
+      expect(result.marking.b_done).toBe(1);
+      expect(result.marking.a_ready).toBe(0);
+      expect(result.marking.b_ready).toBe(0);
+      expect(result.terminal).toBe(true);
+    }
+  });
+
+  it("conflicting transitions don't double-fire", async () => {
+    // Two transitions compete for the same input place
+    type Place = "shared" | "out_a" | "out_b";
+    type Ctx = { winner: string };
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "conflict-test",
+      places: ["shared", "out_a", "out_b"],
+      transitions: [
+        {
+          name: "take_a",
+          type: "automatic",
+          inputs: ["shared"],
+          outputs: ["out_a"],
+          guard: null,
+          execute: async () => ({ winner: "a" }),
+        },
+        {
+          name: "take_b",
+          type: "automatic",
+          inputs: ["shared"],
+          outputs: ["out_b"],
+          guard: null,
+          execute: async () => ({ winner: "b" }),
+        },
+      ],
+      initialMarking: { shared: 1, out_a: 0, out_b: 0 },
+      initialContext: { winner: "" },
+      terminalPlaces: ["out_a", "out_b"],
+    });
+
+    const executor = createExecutor(def);
+    const result = await executor.stepBatch(
+      "inst-1",
+      { shared: 1, out_a: 0, out_b: 0 },
+      { winner: "" },
+      10,
+    );
+
+    expect(result.kind).toBe("fired");
+    if (result.kind === "fired") {
+      // Only one should fire — first-enabled wins
+      expect(result.transitions).toHaveLength(1);
+      expect(result.transitions[0]).toBe("take_a");
+      // Token was consumed from "shared"
+      expect(result.marking.shared).toBe(0);
+    }
+  });
+
+  it("context patches merge in transition-name order", async () => {
+    type Place = "p1" | "p2" | "done1" | "done2";
+    type Ctx = { values: string[]; last: string };
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "merge-test",
+      places: ["p1", "p2", "done1", "done2"],
+      transitions: [
+        {
+          name: "z_second",
+          type: "automatic",
+          inputs: ["p1"],
+          outputs: ["done1"],
+          guard: null,
+          execute: async (ctx) => ({ values: [...ctx.values, "z"], last: "z" }),
+        },
+        {
+          name: "a_first",
+          type: "automatic",
+          inputs: ["p2"],
+          outputs: ["done2"],
+          guard: null,
+          execute: async (ctx) => ({ values: [...ctx.values, "a"], last: "a" }),
+        },
+      ],
+      initialMarking: { p1: 1, p2: 1, done1: 0, done2: 0 },
+      initialContext: { values: [], last: "" },
+      terminalPlaces: ["done1", "done2"],
+    });
+
+    const executor = createExecutor(def);
+    const result = await executor.stepBatch(
+      "inst-1",
+      { p1: 1, p2: 1, done1: 0, done2: 0 },
+      { values: [], last: "" },
+      10,
+    );
+
+    expect(result.kind).toBe("fired");
+    if (result.kind === "fired") {
+      // "a_first" sorts before "z_second", so a_first's patch is applied first,
+      // then z_second's patch overwrites. last should be "z".
+      expect(result.context.last).toBe("z");
+    }
+  });
+
+  it("maxConcurrent=1 behaves identically to step()", async () => {
+    type Place = "p1" | "p2" | "done1" | "done2";
+    type Ctx = { log: string[] };
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "single-batch",
+      places: ["p1", "p2", "done1", "done2"],
+      transitions: [
+        {
+          name: "do_first",
+          type: "automatic",
+          inputs: ["p1"],
+          outputs: ["done1"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "first"] }),
+        },
+        {
+          name: "do_second",
+          type: "automatic",
+          inputs: ["p2"],
+          outputs: ["done2"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "second"] }),
+        },
+      ],
+      initialMarking: { p1: 1, p2: 1, done1: 0, done2: 0 },
+      initialContext: { log: [] },
+      terminalPlaces: ["done1", "done2"],
+    });
+
+    const executor = createExecutor(def);
+    const marking = { p1: 1, p2: 1, done1: 0, done2: 0 } as const;
+    const ctx = { log: [] };
+
+    const stepResult = await executor.step("inst-1", marking, ctx);
+    const batchResult = await executor.stepBatch("inst-1", marking, ctx, 1);
+
+    // Both should fire exactly one transition — the same one (first enabled)
+    expect(stepResult.kind).toBe("fired");
+    expect(batchResult.kind).toBe("fired");
+    if (stepResult.kind === "fired" && batchResult.kind === "fired") {
+      expect(batchResult.transitions).toHaveLength(1);
+      expect(batchResult.transitions[0]).toBe(stepResult.transition);
+      expect(batchResult.marking).toEqual(stepResult.marking);
+      expect(batchResult.context).toEqual(stepResult.context);
+    }
+  });
+
+  it("returns idle when no transitions are enabled", async () => {
+    type Place = "done";
+    type Ctx = Record<string, unknown>;
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "empty-batch",
+      places: ["done"],
+      transitions: [],
+      initialMarking: { done: 1 },
+      initialContext: {},
+      terminalPlaces: ["done"],
+    });
+
+    const executor = createExecutor(def);
+    const result = await executor.stepBatch("inst-1", { done: 1 }, {}, 10);
+    expect(result.kind).toBe("idle");
+  });
+
+  it("respects maxConcurrent limit", async () => {
+    type Place = "a" | "b" | "c" | "da" | "db" | "dc";
+    type Ctx = { log: string[] };
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "limited-batch",
+      places: ["a", "b", "c", "da", "db", "dc"],
+      transitions: [
+        {
+          name: "do_a",
+          type: "automatic",
+          inputs: ["a"],
+          outputs: ["da"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "a"] }),
+        },
+        {
+          name: "do_b",
+          type: "automatic",
+          inputs: ["b"],
+          outputs: ["db"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "b"] }),
+        },
+        {
+          name: "do_c",
+          type: "automatic",
+          inputs: ["c"],
+          outputs: ["dc"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "c"] }),
+        },
+      ],
+      initialMarking: { a: 1, b: 1, c: 1, da: 0, db: 0, dc: 0 },
+      initialContext: { log: [] },
+      terminalPlaces: ["da", "db", "dc"],
+    });
+
+    const executor = createExecutor(def);
+    const result = await executor.stepBatch(
+      "inst-1",
+      { a: 1, b: 1, c: 1, da: 0, db: 0, dc: 0 },
+      { log: [] },
+      2,
+    );
+
+    expect(result.kind).toBe("fired");
+    if (result.kind === "fired") {
+      expect(result.transitions).toHaveLength(2);
+      expect(result.terminal).toBe(false); // one transition left
+    }
+  });
+});
+
+describe("Scheduler with maxConcurrent", () => {
+  it("tick({ maxConcurrent }) fires multiple transitions per tick", async () => {
+    type Place = "a" | "b" | "da" | "db";
+    type Ctx = { log: string[] };
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "batch-sched",
+      places: ["a", "b", "da", "db"],
+      transitions: [
+        {
+          name: "do_a",
+          type: "automatic",
+          inputs: ["a"],
+          outputs: ["da"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "a"] }),
+        },
+        {
+          name: "do_b",
+          type: "automatic",
+          inputs: ["b"],
+          outputs: ["db"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "b"] }),
+        },
+      ],
+      initialMarking: { a: 1, b: 1, da: 0, db: 0 },
+      initialContext: { log: [] },
+      terminalPlaces: ["da", "db"],
+    });
+
+    const db = new Database(":memory:");
+    const fired: string[] = [];
+    const completed: string[] = [];
+
+    const scheduler = new Scheduler(createExecutor(def), { adapter: sqliteAdapter(db, def.name) }, {
+      onFire: (_id, name) => fired.push(name),
+      onComplete: (id) => completed.push(id),
+    });
+
+    await scheduler.createInstance("batch-1");
+    const count = await scheduler.tick({ maxConcurrent: 10 });
+
+    expect(count).toBe(2);
+    expect(fired).toContain("do_a");
+    expect(fired).toContain("do_b");
+    expect(completed).toEqual(["batch-1"]);
+
+    const state = await scheduler.inspect("batch-1");
+    expect(state.status).toBe("completed");
+    expect(state.marking).toEqual({ a: 0, b: 0, da: 1, db: 1 });
+  });
+
+  it("tick() without maxConcurrent still fires one at a time", async () => {
+    type Place = "a" | "b" | "da" | "db";
+    type Ctx = Record<string, unknown>;
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "seq-sched",
+      places: ["a", "b", "da", "db"],
+      transitions: [
+        { name: "do_a", type: "automatic", inputs: ["a"], outputs: ["da"], guard: null },
+        { name: "do_b", type: "automatic", inputs: ["b"], outputs: ["db"], guard: null },
+      ],
+      initialMarking: { a: 1, b: 1, da: 0, db: 0 },
+      initialContext: {},
+      terminalPlaces: ["da", "db"],
+    });
+
+    const db = new Database(":memory:");
+    const scheduler = new Scheduler(createExecutor(def), { adapter: sqliteAdapter(db, def.name) });
+
+    await scheduler.createInstance("seq-1");
+    const count = await scheduler.tick();
+
+    // Sequential: only one transition per tick
+    expect(count).toBe(1);
+  });
+});

--- a/packages/engine/src/batch.test.ts
+++ b/packages/engine/src/batch.test.ts
@@ -226,6 +226,30 @@ describe("stepBatch", () => {
     expect(result.kind).toBe("idle");
   });
 
+  it("throws on maxConcurrent < 1", async () => {
+    type Place = "a" | "da";
+    type Ctx = Record<string, unknown>;
+
+    const def = defineWorkflow<Place, Ctx>({
+      name: "validate-max",
+      places: ["a", "da"],
+      transitions: [
+        { name: "do_a", type: "automatic", inputs: ["a"], outputs: ["da"], guard: null },
+      ],
+      initialMarking: { a: 1, da: 0 },
+      initialContext: {},
+      terminalPlaces: ["da"],
+    });
+
+    const executor = createExecutor(def);
+    await expect(executor.stepBatch("inst-1", { a: 1, da: 0 }, {}, 0)).rejects.toThrow(
+      "maxConcurrent must be >= 1",
+    );
+    await expect(executor.stepBatch("inst-1", { a: 1, da: 0 }, {}, -1)).rejects.toThrow(
+      "maxConcurrent must be >= 1",
+    );
+  });
+
   it("respects maxConcurrent limit", async () => {
     type Place = "a" | "b" | "c" | "da" | "db" | "dc";
     type Ctx = { log: string[] };

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -48,6 +48,25 @@ export interface WorkflowExecutor<
     marking: Marking<Place>,
     ctx: Ctx,
   ): Promise<StepResult<Place, Ctx>>;
+  /**
+   * Fire up to `maxConcurrent` non-conflicting transitions in parallel.
+   *
+   * **Execution model:** Each executor receives the original (pre-fire)
+   * marking and context snapshot. Executors cannot see each other's
+   * patches — they run concurrently via Promise.all.
+   *
+   * **Context merge:** Patches are merged in transition-name order
+   * (alphabetical) using shallow spread. Executors in a batch should
+   * write to disjoint context keys. Overlapping keys use last-writer-wins
+   * based on name order — compound values (arrays, objects) are replaced,
+   * not deep-merged.
+   *
+   * **Error handling:** If any executor throws, the entire batch fails
+   * (Promise.all semantics). The scheduler marks the instance as failed
+   * with the pre-fire marking. Executors that perform side effects should
+   * be idempotent, since a partial batch failure means some executors
+   * completed but none are recorded.
+   */
   stepBatch(
     instanceId: string,
     marking: Marking<Place>,

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1,7 +1,7 @@
 import { canFire, fire, type Marking } from "petri-ts";
 import type { WorkflowDefinition, WorkflowTransition } from "./types.js";
 import type { DecisionProvider } from "./decision.js";
-import { enabledWorkflowTransitions, fireWorkflow, canFireWorkflow } from "./engine.js";
+import { enabledWorkflowTransitions, fireWorkflow } from "./engine.js";
 
 export type StepResult<
   Place extends string,
@@ -147,6 +147,10 @@ export function createExecutor<
       ctx: Ctx,
       maxConcurrent: number,
     ): Promise<BatchStepResult<Place, Ctx>> {
+      if (maxConcurrent < 1) {
+        throw new Error("maxConcurrent must be >= 1");
+      }
+
       const enabled = enabledWorkflowTransitions(
         definition.net,
         marking,

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1,7 +1,7 @@
-import { canFire, type Marking } from "petri-ts";
+import { canFire, fire, type Marking } from "petri-ts";
 import type { WorkflowDefinition, WorkflowTransition } from "./types.js";
 import type { DecisionProvider } from "./decision.js";
-import { enabledWorkflowTransitions, fireWorkflow } from "./engine.js";
+import { enabledWorkflowTransitions, fireWorkflow, canFireWorkflow } from "./engine.js";
 
 export type StepResult<
   Place extends string,
@@ -14,6 +14,19 @@ export type StepResult<
       transition: string;
       terminal: boolean;
       decision?: { reasoning: string; candidates: string[] };
+    }
+  | { kind: "idle" };
+
+export type BatchStepResult<
+  Place extends string,
+  Ctx extends Record<string, unknown>,
+> =
+  | {
+      kind: "fired";
+      marking: Marking<Place>;
+      context: Ctx;
+      transitions: string[];
+      terminal: boolean;
     }
   | { kind: "idle" };
 
@@ -35,6 +48,12 @@ export interface WorkflowExecutor<
     marking: Marking<Place>,
     ctx: Ctx,
   ): Promise<StepResult<Place, Ctx>>;
+  stepBatch(
+    instanceId: string,
+    marking: Marking<Place>,
+    ctx: Ctx,
+    maxConcurrent: number,
+  ): Promise<BatchStepResult<Place, Ctx>>;
   getTimeoutCandidates(marking: Marking<Place>): TimeoutCandidate<Place>[];
 }
 
@@ -119,6 +138,71 @@ export function createExecutor<
         transition: result.firedTransition,
         terminal: nextEnabled.length === 0,
         decision,
+      };
+    },
+
+    async stepBatch(
+      instanceId: string,
+      marking: Marking<Place>,
+      ctx: Ctx,
+      maxConcurrent: number,
+    ): Promise<BatchStepResult<Place, Ctx>> {
+      const enabled = enabledWorkflowTransitions(
+        definition.net,
+        marking,
+        ctx,
+        definition.guards,
+      );
+
+      if (enabled.length === 0) {
+        return { kind: "idle" };
+      }
+
+      // Greedily select non-conflicting transitions by tracking a working marking.
+      // First-enabled wins: if two transitions compete for the same input tokens,
+      // only the first one gets selected.
+      const selected: WorkflowTransition<Place, Ctx>[] = [];
+      let workingMarking = { ...marking } as Marking<Place>;
+
+      for (const t of enabled) {
+        if (selected.length >= maxConcurrent) break;
+        if (canFire(workingMarking, t)) {
+          // Reserve tokens by firing structurally (consume inputs, produce outputs)
+          workingMarking = fire(workingMarking, t);
+          selected.push(t);
+        }
+      }
+
+      // Run all executors in parallel
+      const executorPromises = selected.map(async (t) => {
+        const executeFn = definition.executors.get(t.name);
+        const patch = executeFn ? await executeFn(ctx, marking) : {};
+        return { name: t.name, patch };
+      });
+
+      const results = await Promise.all(executorPromises);
+
+      // Merge context patches in transition-name order (deterministic)
+      const sorted = [...results].sort((a, b) => a.name.localeCompare(b.name));
+      let mergedCtx = { ...ctx };
+      for (const r of sorted) {
+        mergedCtx = { ...mergedCtx, ...r.patch };
+      }
+
+      // workingMarking already reflects all fires
+      const nextEnabled = enabledWorkflowTransitions(
+        definition.net,
+        workingMarking,
+        mergedCtx,
+        definition.guards,
+      );
+
+      return {
+        kind: "fired",
+        marking: workingMarking,
+        context: mergedCtx,
+        transitions: selected.map((t) => t.name),
+        terminal: nextEnabled.length === 0,
       };
     },
   };

--- a/packages/engine/src/expand.test.ts
+++ b/packages/engine/src/expand.test.ts
@@ -179,6 +179,20 @@ describe("expandWorkflow", () => {
     ).toThrow('Terminal place "nonexistent" is not a known place');
   });
 
+  it("rejects duplicate transition names", () => {
+    expect(() =>
+      expandWorkflow(baseDef, [
+        {
+          name: "begin", // already exists
+          type: "automatic",
+          inputs: ["start"],
+          outputs: ["middle"],
+          guard: null,
+        },
+      ]),
+    ).toThrow('Transition "begin" already exists in the definition');
+  });
+
   it("validates expanded definition end-to-end with executor", async () => {
     type EPlace = Place | "branch";
 
@@ -283,6 +297,46 @@ describe("injectTokens", () => {
 });
 
 describe("Scheduler.updateExecutor", () => {
+  it("mid-tick update does not affect the current tick", async () => {
+    const db = new Database(":memory:");
+    const fired: string[] = [];
+
+    const scheduler = new Scheduler(createExecutor(baseDef), { adapter: sqliteAdapter(db, baseDef.name) }, {
+      onFire: (_id, name, _result) => {
+        fired.push(name);
+        // Swap executor mid-tick (during onFire callback)
+        type EPlace = Place | "bonus";
+        const expanded = expandWorkflow<EPlace, Ctx>(
+          baseDef as any,
+          [
+            {
+              name: "do_bonus",
+              type: "automatic",
+              inputs: ["middle"],
+              outputs: ["bonus"],
+              guard: null,
+            },
+          ],
+          ["bonus"],
+          { terminalPlaces: ["bonus"] },
+        );
+        scheduler.updateExecutor(createExecutor(expanded) as any);
+      },
+    });
+
+    await scheduler.createInstance("toctou-1");
+
+    // First tick fires "begin" — the onFire callback swaps executor mid-tick.
+    // The tick should complete using the original executor (not the new one).
+    await scheduler.tick();
+    expect(fired).toEqual(["begin"]);
+
+    // Second tick uses the new executor — "finish" and "do_bonus" both available
+    await scheduler.tick();
+    // Should fire one of them (sequential mode)
+    expect(fired.length).toBe(2);
+  });
+
   it("picks up expanded workflow on next tick", async () => {
     const db = new Database(":memory:");
     const fired: string[] = [];

--- a/packages/engine/src/expand.test.ts
+++ b/packages/engine/src/expand.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import type { Marking } from "petri-ts";
+import { defineWorkflow, expandWorkflow, injectTokens } from "./workflow.js";
+import { createExecutor } from "./executor.js";
+import { enabledWorkflowTransitions } from "./engine.js";
+import { Scheduler } from "./scheduler.js";
+import { sqliteAdapter } from "./persistence/sqlite-adapter.js";
+
+type Place = "start" | "middle" | "end";
+type Ctx = { log: string[] };
+
+const baseDef = defineWorkflow<Place, Ctx>({
+  name: "expand-test",
+  places: ["start", "middle", "end"],
+  transitions: [
+    {
+      name: "begin",
+      type: "automatic",
+      inputs: ["start"],
+      outputs: ["middle"],
+      guard: null,
+      execute: async (ctx) => ({ log: [...ctx.log, "began"] }),
+    },
+    {
+      name: "finish",
+      type: "automatic",
+      inputs: ["middle"],
+      outputs: ["end"],
+      guard: null,
+      execute: async (ctx) => ({ log: [...ctx.log, "finished"] }),
+    },
+  ],
+  initialMarking: { start: 1, middle: 0, end: 0 },
+  initialContext: { log: [] },
+  terminalPlaces: ["end"],
+});
+
+describe("expandWorkflow", () => {
+  it("adds new transitions that wire in correctly", () => {
+    type EPlace = Place | "extra";
+
+    const expanded = expandWorkflow<EPlace, Ctx>(
+      baseDef as any,
+      [
+        {
+          name: "bonus",
+          type: "automatic",
+          inputs: ["middle"],
+          outputs: ["extra"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "bonus"] }),
+        },
+      ],
+      ["extra"],
+      { terminalPlaces: ["extra"] },
+    );
+
+    expect(expanded.net.transitions).toHaveLength(3);
+    expect(expanded.net.transitions.map((t) => t.name)).toContain("bonus");
+    expect(expanded.terminalPlaces).toContain("extra");
+    expect(expanded.executors.has("bonus")).toBe(true);
+  });
+
+  it("preserves existing transitions and executors exactly", () => {
+    type EPlace = Place | "extra";
+
+    const expanded = expandWorkflow<EPlace, Ctx>(
+      baseDef as any,
+      [
+        {
+          name: "bonus",
+          type: "automatic",
+          inputs: ["middle"],
+          outputs: ["extra"],
+          guard: null,
+        },
+      ],
+      ["extra"],
+    );
+
+    // Original transitions unchanged
+    expect(expanded.net.transitions[0]!.name).toBe("begin");
+    expect(expanded.net.transitions[1]!.name).toBe("finish");
+    // Original executors preserved
+    expect(expanded.executors.has("begin")).toBe(true);
+    expect(expanded.executors.has("finish")).toBe(true);
+    // Original definition unchanged
+    expect(baseDef.net.transitions).toHaveLength(2);
+  });
+
+  it("compiles guards on new transitions", () => {
+    type EPlace = Place | "guarded_out";
+
+    const expanded = expandWorkflow<EPlace, Ctx>(
+      baseDef as any,
+      [
+        {
+          name: "guarded",
+          type: "automatic",
+          inputs: ["middle"],
+          outputs: ["guarded_out"],
+          guard: "log.length > 0",
+        },
+      ],
+      ["guarded_out"],
+    );
+
+    expect(expanded.guards.has("guarded")).toBe(true);
+
+    // Guard should evaluate correctly
+    const marking = { start: 0, middle: 1, end: 0, guarded_out: 0 } as any;
+    const enabled = enabledWorkflowTransitions(
+      expanded.net,
+      marking,
+      { log: ["something"] },
+      expanded.guards,
+    );
+    expect(enabled.map((t) => t.name)).toContain("guarded");
+
+    const enabledEmpty = enabledWorkflowTransitions(
+      expanded.net,
+      marking,
+      { log: [] },
+      expanded.guards,
+    );
+    expect(enabledEmpty.map((t) => t.name)).not.toContain("guarded");
+  });
+
+  it("does not mutate the original definition", () => {
+    type EPlace = Place | "new_place";
+
+    const originalTransitionCount = baseDef.net.transitions.length;
+    const originalGuardCount = baseDef.guards.size;
+    const originalExecutorCount = baseDef.executors.size;
+    const originalTerminalCount = baseDef.terminalPlaces.length;
+
+    expandWorkflow<EPlace, Ctx>(
+      baseDef as any,
+      [
+        {
+          name: "extra",
+          type: "automatic",
+          inputs: ["middle"],
+          outputs: ["new_place"],
+          guard: "log.length > 0",
+          execute: async (ctx) => ({ log: [...ctx.log, "extra"] }),
+        },
+      ],
+      ["new_place"],
+      { terminalPlaces: ["new_place"] },
+    );
+
+    expect(baseDef.net.transitions.length).toBe(originalTransitionCount);
+    expect(baseDef.guards.size).toBe(originalGuardCount);
+    expect(baseDef.executors.size).toBe(originalExecutorCount);
+    expect(baseDef.terminalPlaces.length).toBe(originalTerminalCount);
+  });
+
+  it("rejects transitions referencing unknown places", () => {
+    expect(() =>
+      expandWorkflow(baseDef, [
+        {
+          name: "bad",
+          type: "automatic",
+          inputs: ["nonexistent" as Place],
+          outputs: ["end"],
+          guard: null,
+        },
+      ]),
+    ).toThrow('Transition "bad" references unknown input place "nonexistent"');
+  });
+
+  it("rejects unknown terminal places", () => {
+    expect(() =>
+      expandWorkflow(baseDef, [], undefined, {
+        terminalPlaces: ["nonexistent" as Place],
+      }),
+    ).toThrow('Terminal place "nonexistent" is not a known place');
+  });
+
+  it("validates expanded definition end-to-end with executor", async () => {
+    type EPlace = Place | "branch";
+
+    const expanded = expandWorkflow<EPlace, Ctx>(
+      baseDef as any,
+      [
+        {
+          name: "branch_off",
+          type: "automatic",
+          inputs: ["middle"],
+          outputs: ["branch"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "branched"] }),
+        },
+      ],
+      ["branch"],
+      { terminalPlaces: ["branch"] },
+    );
+
+    const executor = createExecutor(expanded);
+    // Fire "begin" first
+    const r1 = await executor.step(
+      "inst-1",
+      { start: 1, middle: 0, end: 0, branch: 0 } as any,
+      { log: [] },
+    );
+    expect(r1.kind).toBe("fired");
+    if (r1.kind === "fired") {
+      expect(r1.transition).toBe("begin");
+      // Now from middle, both "finish" and "branch_off" should be enabled
+      const enabled = enabledWorkflowTransitions(
+        expanded.net,
+        r1.marking,
+        r1.context,
+        expanded.guards,
+      );
+      expect(enabled.map((t) => t.name)).toContain("finish");
+      expect(enabled.map((t) => t.name)).toContain("branch_off");
+    }
+  });
+});
+
+describe("injectTokens", () => {
+  it("adds tokens to an existing place", () => {
+    const marking = { start: 0, middle: 0, end: 0 };
+    const result = injectTokens(marking, "middle", 2);
+    expect(result.middle).toBe(2);
+    // Original unchanged
+    expect(marking.middle).toBe(0);
+  });
+
+  it("defaults count to 1", () => {
+    const marking = { start: 0, middle: 0, end: 0 };
+    const result = injectTokens(marking, "start");
+    expect(result.start).toBe(1);
+  });
+
+  it("adds to existing token count", () => {
+    const marking = { start: 3, middle: 0, end: 0 };
+    const result = injectTokens(marking, "start", 2);
+    expect(result.start).toBe(5);
+  });
+
+  it("injected tokens enable new transitions", () => {
+    type IPlace = "waiting" | "approval" | "done";
+    type ICtx = Record<string, unknown>;
+
+    const def = defineWorkflow<IPlace, ICtx>({
+      name: "inject-enable",
+      places: ["waiting", "approval", "done"],
+      transitions: [
+        {
+          name: "process",
+          type: "automatic",
+          inputs: ["waiting", "approval"],
+          outputs: ["done"],
+          guard: null,
+        },
+      ],
+      initialMarking: { waiting: 1, approval: 0, done: 0 },
+      initialContext: {},
+      terminalPlaces: ["done"],
+    });
+
+    const marking = { waiting: 1, approval: 0, done: 0 } as Marking<IPlace>;
+
+    // Without injection — no enabled transitions
+    let enabled = enabledWorkflowTransitions<IPlace, ICtx>(
+      def.net,
+      marking,
+      {},
+      def.guards,
+    );
+    expect(enabled).toHaveLength(0);
+
+    // After injection — transition becomes enabled
+    const injected = injectTokens<IPlace>(marking, "approval");
+    enabled = enabledWorkflowTransitions<IPlace, ICtx>(def.net, injected, {}, def.guards);
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0]!.name).toBe("process");
+  });
+});
+
+describe("Scheduler.updateExecutor", () => {
+  it("picks up expanded workflow on next tick", async () => {
+    const db = new Database(":memory:");
+    const fired: string[] = [];
+
+    const scheduler = new Scheduler(createExecutor(baseDef), { adapter: sqliteAdapter(db, baseDef.name) }, {
+      onFire: (_id, name) => fired.push(name),
+    });
+
+    await scheduler.createInstance("expand-1");
+
+    // Tick once — fires "begin"
+    await scheduler.tick();
+    expect(fired).toEqual(["begin"]);
+
+    // Now expand the definition with a new transition from "middle"
+    type EPlace = Place | "bonus";
+    const expanded = expandWorkflow<EPlace, Ctx>(
+      baseDef as any,
+      [
+        {
+          name: "do_bonus",
+          type: "automatic",
+          inputs: ["middle"],
+          outputs: ["bonus"],
+          guard: null,
+          execute: async (ctx) => ({ log: [...ctx.log, "bonus"] }),
+        },
+      ],
+      ["bonus"],
+      { terminalPlaces: ["bonus"] },
+    );
+
+    // Update the scheduler's executor
+    scheduler.updateExecutor(createExecutor(expanded) as any);
+
+    // Tick again — now "finish" and "do_bonus" are both enabled from "middle"
+    // Sequential step fires the first one: "finish"
+    await scheduler.tick();
+    expect(fired).toContain("finish");
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -34,7 +34,7 @@ export type {
 } from "./types.js";
 
 // Workflow definition helpers
-export { defineWorkflow, toNet } from "./workflow.js";
+export { defineWorkflow, expandWorkflow, injectTokens, toNet } from "./workflow.js";
 
 // Guard compilation
 export { compileGuard } from "./guard.js";
@@ -73,7 +73,7 @@ export type {
 
 // Executor
 export { createExecutor } from "./executor.js";
-export type { WorkflowExecutor, StepResult, TimeoutCandidate } from "./executor.js";
+export type { WorkflowExecutor, StepResult, BatchStepResult, TimeoutCandidate } from "./executor.js";
 
 // Scheduler
 export { Scheduler } from "./scheduler.js";

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -39,7 +39,7 @@ export class Scheduler<
   private ticking = false;
   private readonly pollIntervalMs: number;
   private readonly adapter: WorkflowPersistence<Place, Ctx>;
-  private readonly executor: WorkflowExecutor<Place, Ctx>;
+  private executor: WorkflowExecutor<Place, Ctx>;
   private readonly events: SchedulerEvents<Place, Ctx>;
 
   constructor(
@@ -66,10 +66,11 @@ export class Scheduler<
     return this.executor.initialMarking;
   }
 
-  async tick(): Promise<number> {
+  async tick(options?: { maxConcurrent?: number }): Promise<number> {
     if (this.ticking) return 0;
     this.ticking = true;
     let totalFired = 0;
+    const maxConcurrent = options?.maxConcurrent;
 
     try {
       const activeIds = await this.adapter.listActive();
@@ -96,96 +97,184 @@ export class Scheduler<
             await this.adapter.saveExtended(id, state);
           }
 
-          // Phase 2: Step (same as before)
-          const result = await this.executor.step(
-            id,
-            state.marking,
-            state.context,
-          );
+          // Phase 2: Step — use batch or sequential based on maxConcurrent
+          if (maxConcurrent != null && maxConcurrent > 1) {
+            const result = await this.executor.stepBatch(
+              id,
+              state.marking,
+              state.context,
+              maxConcurrent,
+            );
 
-          // Phase 3: Schedule/cancel timeouts based on new marking
-          let postCandidates;
-          if (result.kind === "fired") {
-            await this.adapter.clearTimeouts(id, result.transition);
-            postCandidates = this.executor.getTimeoutCandidates(result.marking);
-          } else {
-            postCandidates = this.executor.getTimeoutCandidates(state.marking);
-          }
-
-          // Cancel entries for transitions that lost enablement
-          const postNames = new Set(postCandidates.map((c) => c.transitionName));
-          for (const pre of preCandidates) {
-            if (!postNames.has(pre.transitionName)) {
-              await this.adapter.clearTimeouts(id, pre.transitionName);
+            // Phase 3: Schedule/cancel timeouts based on new marking
+            let postCandidates;
+            if (result.kind === "fired") {
+              for (const t of result.transitions) {
+                await this.adapter.clearTimeouts(id, t);
+              }
+              postCandidates = this.executor.getTimeoutCandidates(result.marking);
+            } else {
+              postCandidates = this.executor.getTimeoutCandidates(state.marking);
             }
-          }
 
-          // Schedule new timeouts
-          const now = Date.now();
-          for (const candidate of postCandidates) {
-            await this.adapter.scheduleTimeout({
-              id: `${id}:${candidate.transitionName}:${now}`,
-              instanceId: id,
-              transitionName: candidate.transitionName,
-              place: candidate.place,
-              fireAt: now + candidate.ms,
-            });
-          }
+            const postNames = new Set(postCandidates.map((c) => c.transitionName));
+            for (const pre of preCandidates) {
+              if (!postNames.has(pre.transitionName)) {
+                await this.adapter.clearTimeouts(id, pre.transitionName);
+              }
+            }
 
-          // Phase 4: Handle step result
-          if (result.kind === "idle") {
-            const hasPending = await this.adapter.hasPendingTimeouts(id);
-            if (!hasPending) {
-              await this.adapter.saveExtended(id, {
-                ...state,
-                status: "completed",
+            const now = Date.now();
+            for (const candidate of postCandidates) {
+              await this.adapter.scheduleTimeout({
+                id: `${id}:${candidate.transitionName}:${now}`,
+                instanceId: id,
+                transitionName: candidate.transitionName,
+                place: candidate.place,
+                fireAt: now + candidate.ms,
               });
+            }
+
+            // Phase 4: Handle batch result
+            if (result.kind === "idle") {
+              const hasPending = await this.adapter.hasPendingTimeouts(id);
+              if (!hasPending) {
+                await this.adapter.saveExtended(id, {
+                  ...state,
+                  status: "completed",
+                });
+                this.events.onComplete?.(id);
+              }
+              continue;
+            }
+
+            let status: "active" | "completed" = result.terminal ? "completed" : "active";
+            if (result.terminal) {
+              const hasPending = await this.adapter.hasPendingTimeouts(id);
+              if (hasPending) {
+                status = "active";
+              }
+            }
+            await this.adapter.saveExtended(id, {
+              marking: result.marking,
+              workflowName: state.workflowName,
+              context: result.context,
+              status,
+            });
+
+            for (const t of result.transitions) {
+              await this.adapter.recordTransition({
+                instanceId: id,
+                workflowName: state.workflowName,
+                transitionName: t,
+                markingBefore: state.marking,
+                markingAfter: result.marking,
+                contextAfter: result.context,
+                firedAt: Date.now(),
+              });
+
+              this.events.onFire?.(id, t, {
+                marking: result.marking,
+                context: result.context,
+              });
+            }
+            totalFired += result.transitions.length;
+
+            if (status === "completed") {
               this.events.onComplete?.(id);
             }
-            continue;
-          }
-
-          if (result.decision) {
-            this.events.onDecision?.(
+          } else {
+            // Sequential path (original behavior)
+            const result = await this.executor.step(
               id,
-              result.transition,
-              result.decision.reasoning,
-              result.decision.candidates,
+              state.marking,
+              state.context,
             );
-          }
 
-          let status: "active" | "completed" = result.terminal ? "completed" : "active";
-          if (result.terminal) {
-            const hasPending = await this.adapter.hasPendingTimeouts(id);
-            if (hasPending) {
-              status = "active";
+            // Phase 3: Schedule/cancel timeouts based on new marking
+            let postCandidates;
+            if (result.kind === "fired") {
+              await this.adapter.clearTimeouts(id, result.transition);
+              postCandidates = this.executor.getTimeoutCandidates(result.marking);
+            } else {
+              postCandidates = this.executor.getTimeoutCandidates(state.marking);
             }
-          }
-          await this.adapter.saveExtended(id, {
-            marking: result.marking,
-            workflowName: state.workflowName,
-            context: result.context,
-            status,
-          });
 
-          await this.adapter.recordTransition({
-            instanceId: id,
-            workflowName: state.workflowName,
-            transitionName: result.transition,
-            markingBefore: state.marking,
-            markingAfter: result.marking,
-            contextAfter: result.context,
-            firedAt: Date.now(),
-          });
+            // Cancel entries for transitions that lost enablement
+            const postNames = new Set(postCandidates.map((c) => c.transitionName));
+            for (const pre of preCandidates) {
+              if (!postNames.has(pre.transitionName)) {
+                await this.adapter.clearTimeouts(id, pre.transitionName);
+              }
+            }
 
-          this.events.onFire?.(id, result.transition, {
-            marking: result.marking,
-            context: result.context,
-          });
-          totalFired++;
+            // Schedule new timeouts
+            const now = Date.now();
+            for (const candidate of postCandidates) {
+              await this.adapter.scheduleTimeout({
+                id: `${id}:${candidate.transitionName}:${now}`,
+                instanceId: id,
+                transitionName: candidate.transitionName,
+                place: candidate.place,
+                fireAt: now + candidate.ms,
+              });
+            }
 
-          if (status === "completed") {
-            this.events.onComplete?.(id);
+            // Phase 4: Handle step result
+            if (result.kind === "idle") {
+              const hasPending = await this.adapter.hasPendingTimeouts(id);
+              if (!hasPending) {
+                await this.adapter.saveExtended(id, {
+                  ...state,
+                  status: "completed",
+                });
+                this.events.onComplete?.(id);
+              }
+              continue;
+            }
+
+            if (result.decision) {
+              this.events.onDecision?.(
+                id,
+                result.transition,
+                result.decision.reasoning,
+                result.decision.candidates,
+              );
+            }
+
+            let status: "active" | "completed" = result.terminal ? "completed" : "active";
+            if (result.terminal) {
+              const hasPending = await this.adapter.hasPendingTimeouts(id);
+              if (hasPending) {
+                status = "active";
+              }
+            }
+            await this.adapter.saveExtended(id, {
+              marking: result.marking,
+              workflowName: state.workflowName,
+              context: result.context,
+              status,
+            });
+
+            await this.adapter.recordTransition({
+              instanceId: id,
+              workflowName: state.workflowName,
+              transitionName: result.transition,
+              markingBefore: state.marking,
+              markingAfter: result.marking,
+              contextAfter: result.context,
+              firedAt: Date.now(),
+            });
+
+            this.events.onFire?.(id, result.transition, {
+              marking: result.marking,
+              context: result.context,
+            });
+            totalFired++;
+
+            if (status === "completed") {
+              this.events.onComplete?.(id);
+            }
           }
         } catch (err) {
           this.events.onError?.(id, err);
@@ -220,6 +309,10 @@ export class Scheduler<
       marking,
       status: "active",
     });
+  }
+
+  updateExecutor(executor: WorkflowExecutor<Place, Ctx>): void {
+    this.executor = executor;
   }
 
   start(): void {

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -71,6 +71,8 @@ export class Scheduler<
     this.ticking = true;
     let totalFired = 0;
     const maxConcurrent = options?.maxConcurrent;
+    // Snapshot executor at tick start so updateExecutor() mid-tick is safe
+    const executor = this.executor;
 
     try {
       const activeIds = await this.adapter.listActive();
@@ -81,7 +83,7 @@ export class Scheduler<
         try {
           // Phase 1: Handle expired timeouts
           const expired = await this.adapter.getExpiredTimeouts(id, Date.now());
-          const preCandidates = this.executor.getTimeoutCandidates(state.marking);
+          const preCandidates = executor.getTimeoutCandidates(state.marking);
           const enabledSet = new Set(preCandidates.map((c) => c.transitionName));
 
           for (const entry of expired) {
@@ -99,7 +101,7 @@ export class Scheduler<
 
           // Phase 2: Step — use batch or sequential based on maxConcurrent
           if (maxConcurrent != null && maxConcurrent > 1) {
-            const result = await this.executor.stepBatch(
+            const result = await executor.stepBatch(
               id,
               state.marking,
               state.context,
@@ -112,9 +114,9 @@ export class Scheduler<
               for (const t of result.transitions) {
                 await this.adapter.clearTimeouts(id, t);
               }
-              postCandidates = this.executor.getTimeoutCandidates(result.marking);
+              postCandidates = executor.getTimeoutCandidates(result.marking);
             } else {
-              postCandidates = this.executor.getTimeoutCandidates(state.marking);
+              postCandidates = executor.getTimeoutCandidates(state.marking);
             }
 
             const postNames = new Set(postCandidates.map((c) => c.transitionName));
@@ -185,7 +187,7 @@ export class Scheduler<
             }
           } else {
             // Sequential path (original behavior)
-            const result = await this.executor.step(
+            const result = await executor.step(
               id,
               state.marking,
               state.context,
@@ -195,9 +197,9 @@ export class Scheduler<
             let postCandidates;
             if (result.kind === "fired") {
               await this.adapter.clearTimeouts(id, result.transition);
-              postCandidates = this.executor.getTimeoutCandidates(result.marking);
+              postCandidates = executor.getTimeoutCandidates(result.marking);
             } else {
-              postCandidates = this.executor.getTimeoutCandidates(state.marking);
+              postCandidates = executor.getTimeoutCandidates(state.marking);
             }
 
             // Cancel entries for transitions that lost enablement

--- a/packages/engine/src/workflow.ts
+++ b/packages/engine/src/workflow.ts
@@ -164,6 +164,16 @@ export function expandWorkflow<
     }
   }
 
+  // Check for duplicate transition names
+  const existingNames = new Set(definition.net.transitions.map((t) => t.name));
+  for (const t of newTransitions) {
+    if (existingNames.has(t.name)) {
+      throw new Error(
+        `Transition "${t.name}" already exists in the definition`,
+      );
+    }
+  }
+
   // Validate new transitions reference known places
   for (const t of newTransitions) {
     for (const p of t.inputs) {

--- a/packages/engine/src/workflow.ts
+++ b/packages/engine/src/workflow.ts
@@ -127,6 +127,142 @@ export function defineWorkflow<
 }
 
 /**
+ * Expands a workflow definition with new transitions and optional new places.
+ * Returns a new WorkflowDefinition — does not mutate the original.
+ * Applies the same validation as defineWorkflow().
+ */
+export function expandWorkflow<
+  Place extends string,
+  Ctx extends Record<string, unknown> = Record<string, unknown>,
+>(
+  definition: WorkflowDefinition<Place, Ctx>,
+  newTransitions: TransitionInput<Place, Ctx>[],
+  newPlaces?: Place[],
+  options?: {
+    terminalPlaces?: Place[];
+    nodes?: Map<string, NodeExecutor>;
+  },
+): WorkflowDefinition<Place, Ctx> {
+  // Build the full place set: existing places + new places
+  const existingPlaces = new Set<string>();
+  for (const p of Object.keys(definition.net.initialMarking)) {
+    existingPlaces.add(p);
+  }
+  for (const t of definition.net.transitions) {
+    for (const p of t.inputs) existingPlaces.add(p);
+    for (const p of t.outputs) existingPlaces.add(p);
+    if (t.timeout) existingPlaces.add(t.timeout.place);
+  }
+  for (const p of definition.terminalPlaces) {
+    existingPlaces.add(p);
+  }
+
+  const placeSet = new Set<string>(existingPlaces);
+  if (newPlaces) {
+    for (const p of newPlaces) {
+      placeSet.add(p);
+    }
+  }
+
+  // Validate new transitions reference known places
+  for (const t of newTransitions) {
+    for (const p of t.inputs) {
+      if (!placeSet.has(p)) {
+        throw new Error(
+          `Transition "${t.name}" references unknown input place "${p}"`,
+        );
+      }
+    }
+    for (const p of t.outputs) {
+      if (!placeSet.has(p)) {
+        throw new Error(
+          `Transition "${t.name}" references unknown output place "${p}"`,
+        );
+      }
+    }
+    if (t.timeout && !placeSet.has(t.timeout.place)) {
+      throw new Error(
+        `Transition "${t.name}" timeout references unknown place "${t.timeout.place}"`,
+      );
+    }
+  }
+
+  // Validate new terminal places
+  const terminalPlaces = options?.terminalPlaces
+    ? [...definition.terminalPlaces, ...options.terminalPlaces]
+    : [...definition.terminalPlaces];
+
+  for (const p of terminalPlaces) {
+    if (!placeSet.has(p)) {
+      throw new Error(
+        `Terminal place "${p}" is not a known place`,
+      );
+    }
+  }
+
+  // Copy existing guards and executors
+  const guards = new Map(definition.guards);
+  const executors = new Map(definition.executors);
+
+  // Compile guards for new transitions
+  for (const t of newTransitions) {
+    if (t.guard) {
+      guards.set(t.name, compileGuard(t.guard));
+    }
+  }
+
+  // Extract execute functions from new transitions
+  const newTransitionDefs: WorkflowTransition<Place, Ctx>[] = [];
+  for (const t of newTransitions) {
+    if (t.execute) {
+      executors.set(t.name, t.execute);
+    }
+    const { execute: _, ...rest } = t;
+    newTransitionDefs.push(rest);
+  }
+
+  // Compile executors from type + config via node registry
+  const nodes = options?.nodes ?? defaultNodes();
+  for (const t of newTransitionDefs) {
+    if (executors.has(t.name)) continue;
+    if (!t.config) continue;
+    const node = nodes.get(t.type);
+    if (!node) continue;
+    node.validate(t.config);
+    const config = t.config;
+    executors.set(t.name, ((ctx: Ctx, marking: Marking<Place>) =>
+      node.execute({ ctx, marking, config, transitionName: t.name })) as ExecuteFn<Place, Ctx>);
+  }
+
+  return {
+    name: definition.name,
+    net: {
+      transitions: [...definition.net.transitions, ...newTransitionDefs],
+      initialMarking: definition.net.initialMarking,
+    },
+    guards,
+    executors,
+    initialContext: definition.initialContext,
+    terminalPlaces,
+    invariants: definition.invariants,
+  };
+}
+
+/**
+ * Returns a new marking with additional tokens injected into a place.
+ * Useful when expanding a net where some prerequisites are already satisfied.
+ */
+export function injectTokens<Place extends string>(
+  marking: Marking<Place>,
+  place: Place,
+  count: number = 1,
+): Marking<Place> {
+  const newMarking = { ...marking };
+  newMarking[place] = ((newMarking[place] ?? 0) + count) as Marking<Place>[Place];
+  return newMarking;
+}
+
+/**
  * Strips workflow extensions (guard, execute, timeout) to produce
  * a plain PetriNet compatible with all petri-ts analysis functions.
  */

--- a/site/src/pages/docs/engine.astro
+++ b/site/src/pages/docs/engine.astro
@@ -328,8 +328,11 @@ const executionResultType = `type ExecutionResult<Place, Ctx> = {
       <Code code={batchConflictExample} lang="typescript" />
 
       <h3>Context merge</h3>
-      <p>Each executor runs independently against the original context and returns a partial patch. Patches are merged in transition-name order (alphabetical) for deterministic results. Later patches overwrite earlier ones on shared keys.</p>
+      <p>Each executor receives the original (pre-fire) context snapshot — executors cannot see each other's patches. Patches are merged in transition-name order (alphabetical) using shallow spread. Later patches overwrite earlier ones on shared keys. <strong style="color:var(--text-secondary)">Executors in a batch should write to disjoint context keys.</strong> Overlapping compound values (arrays, objects) are replaced, not deep-merged.</p>
       <Code code={batchMergeExample} lang="typescript" />
+
+      <h3>Error handling</h3>
+      <p><code>stepBatch</code> uses <code>Promise.all</code> — if any executor throws, the entire batch fails. The scheduler marks the instance as failed with the pre-fire marking (no tokens are lost). However, executors that completed before the failure already performed their side effects, which won't be recorded. <strong style="color:var(--text-secondary)">Executors that perform side effects should be idempotent</strong>, since a retry after partial failure may re-run executors that already succeeded.</p>
 
       <Trace label="// stepBatch fires independent transitions in parallel" steps={[
         { icon: "ok", html: `Two independent branches: <strong>do_a</strong> (a_ready&rarr;a_done) and <strong>do_b</strong> (b_ready&rarr;b_done)<br><span class="ok-text">BOTH FIRE</span> in parallel via Promise.all` },
@@ -394,7 +397,7 @@ const executionResultType = `type ExecutionResult<Place, Ctx> = {
       <h3><code>WorkflowExecutor</code></h3>
       <ul>
         <li><strong style="color:var(--text-secondary)">step(instanceId, marking, ctx)</strong>: fire one enabled transition. Returns <code>StepResult</code>.</li>
-        <li><strong style="color:var(--text-secondary)">stepBatch(instanceId, marking, ctx, maxConcurrent)</strong>: fire up to <code>maxConcurrent</code> non-conflicting transitions in parallel. Returns <code>BatchStepResult</code>.</li>
+        <li><strong style="color:var(--text-secondary)">stepBatch(instanceId, marking, ctx, maxConcurrent)</strong>: fire up to <code>maxConcurrent</code> non-conflicting transitions in parallel. Returns <code>BatchStepResult</code>. Executors receive the original context snapshot and should write to disjoint keys (shallow merge, last-writer-wins on conflicts). All-or-nothing on failure — executors should be idempotent.</li>
         <li><strong style="color:var(--text-secondary)">getTimeoutCandidates(marking)</strong>: returns transitions with timeouts that are currently enabled.</li>
       </ul>
 

--- a/site/src/pages/docs/engine.astro
+++ b/site/src/pages/docs/engine.astro
@@ -1,0 +1,448 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import Nav from "../../components/Nav.astro";
+import Footer from "../../components/Footer.astro";
+import Trace from "../../components/Trace.astro";
+import InstallBar from "../../components/InstallBar.astro";
+import { Code } from "astro:components";
+
+const base = import.meta.env.BASE_URL;
+
+const defineWorkflowExample = `import { defineWorkflow, createExecutor, Scheduler } from "@petriflow/engine";
+
+const definition = defineWorkflow({
+  name: "deploy-pipeline",
+  places: ["idle", "tested", "staged", "deployed"],
+  transitions: [
+    {
+      name: "test",
+      type: "automatic",
+      inputs: ["idle"],
+      outputs: ["tested"],
+      guard: null,
+      execute: async (ctx) => ({ log: [...ctx.log, "tested"] }),
+    },
+    {
+      name: "stage",
+      type: "automatic",
+      inputs: ["tested"],
+      outputs: ["staged"],
+      guard: null,
+      execute: async (ctx) => ({ log: [...ctx.log, "staged"] }),
+    },
+    {
+      name: "deploy",
+      type: "automatic",
+      inputs: ["staged"],
+      outputs: ["deployed"],
+      guard: "approved == true",
+      execute: async (ctx) => ({ log: [...ctx.log, "deployed"] }),
+    },
+  ],
+  initialMarking: { idle: 1, tested: 0, staged: 0, deployed: 0 },
+  initialContext: { log: [], approved: false },
+  terminalPlaces: ["deployed"],
+});`;
+
+const guardExample = `// Guards are expressions evaluated against the context
+{
+  name: "approve",
+  type: "automatic",
+  inputs: ["review"],
+  outputs: ["approved"],
+  guard: "amount < 10000",        // simple comparison
+}
+
+{
+  name: "escalate",
+  type: "automatic",
+  inputs: ["review"],
+  outputs: ["escalated"],
+  guard: "amount >= 10000 and not vipCustomer",  // boolean logic
+}
+
+{
+  name: "timeout-check",
+  type: "automatic",
+  inputs: ["waiting"],
+  outputs: ["expired"],
+  guard: "marking.retries == 0",  // access marking via marking.place
+}`;
+
+const executorExample = `import { createExecutor } from "@petriflow/engine";
+
+const executor = createExecutor(definition);
+
+// Fire one transition at a time
+const result = await executor.step("instance-1", marking, context);
+
+if (result.kind === "fired") {
+  console.log(result.transition);  // "test"
+  console.log(result.marking);     // { idle: 0, tested: 1, staged: 0, deployed: 0 }
+  console.log(result.context);     // { log: ["tested"], approved: false }
+  console.log(result.terminal);    // false — more transitions available
+} else {
+  // result.kind === "idle" — no enabled transitions
+}`;
+
+const stepBatchExample = `// Fire multiple independent transitions concurrently
+const result = await executor.stepBatch("instance-1", marking, context, 4);
+
+if (result.kind === "fired") {
+  console.log(result.transitions);  // ["do_a", "do_b"] — all that fired
+  console.log(result.marking);      // tokens consumed/produced for all
+  console.log(result.context);      // patches merged in name order
+  console.log(result.terminal);     // true if no transitions remain
+}`;
+
+const batchConflictExample = `// Two transitions compete for the same input token:
+//   take_a: [shared] → [out_a]
+//   take_b: [shared] → [out_b]
+//
+// With shared:1, only take_a fires (first-enabled wins).
+// take_b is skipped — its input token was already consumed.
+
+const result = await executor.stepBatch("inst", { shared: 1, out_a: 0, out_b: 0 }, ctx, 10);
+// result.transitions === ["take_a"]`;
+
+const batchMergeExample = `// Context patches merge in transition-name order (deterministic).
+// If do_alpha and do_zeta both fire:
+//   1. do_alpha's patch applied first  (alphabetically first)
+//   2. do_zeta's patch applied second  (overwrites shared keys)
+//
+// stepBatch(id, m, ctx, 1) behaves identically to step(id, m, ctx)`;
+
+const schedulerExample = `import { Scheduler } from "@petriflow/engine";
+import { Database } from "bun:sqlite";
+import { sqliteAdapter } from "@petriflow/engine";
+
+const db = new Database("workflow.db");
+const scheduler = new Scheduler(
+  createExecutor(definition),
+  { adapter: sqliteAdapter(db, definition.name) },
+  {
+    onFire: (id, transition, result) => {
+      console.log(\`[\${id}] fired \${transition}\`);
+    },
+    onComplete: (id) => console.log(\`[\${id}] completed\`),
+    onError: (id, err) => console.error(\`[\${id}] error:\`, err),
+  },
+);
+
+await scheduler.createInstance("deploy-001");
+
+// Sequential: fires one transition per tick
+await scheduler.tick();
+
+// Concurrent: fires up to 4 independent transitions per tick
+await scheduler.tick({ maxConcurrent: 4 });
+
+// Poll automatically
+scheduler.start();  // ticks every 1000ms by default
+scheduler.stop();`;
+
+const expandExample = `import { expandWorkflow, injectTokens, createExecutor } from "@petriflow/engine";
+
+// Original definition has: idle → tested → staged → deployed
+// Add a rollback path from staged back to tested
+
+const expanded = expandWorkflow(
+  definition,
+  [
+    {
+      name: "rollback",
+      type: "automatic",
+      inputs: ["staged"],
+      outputs: ["tested"],
+      guard: "rollbackRequested == true",
+      execute: async (ctx) => ({
+        log: [...ctx.log, "rolled back"],
+        rollbackRequested: false,
+      }),
+    },
+  ],
+  // No new places needed — rollback uses existing places
+);
+
+// expanded is a new WorkflowDefinition. Original is unchanged.
+// Guards are compiled, executors extracted — same as defineWorkflow().`;
+
+const expandNewPlacesExample = `// Add entirely new places and terminal states
+const withAudit = expandWorkflow(
+  definition,
+  [
+    {
+      name: "audit",
+      type: "automatic",
+      inputs: ["deployed"],
+      outputs: ["audited"],
+      guard: null,
+      execute: async (ctx) => ({ log: [...ctx.log, "audited"] }),
+    },
+  ],
+  ["audited"],                      // new places
+  { terminalPlaces: ["audited"] },  // new terminal places
+);`;
+
+const injectTokensExample = `import { injectTokens } from "@petriflow/engine";
+
+// A transition needs tokens in two places: [waiting, approval] → [done]
+// "waiting" has a token but "approval" doesn't — transition is blocked.
+const marking = { waiting: 1, approval: 0, done: 0 };
+
+// Inject a token to represent an external approval
+const updated = injectTokens(marking, "approval");
+// { waiting: 1, approval: 1, done: 0 }
+// Now the transition is enabled.
+
+// injectTokens is pure — original marking is unchanged.
+// Works with the Scheduler too:
+await scheduler.injectToken("instance-1", "approval");`;
+
+const updateExecutorExample = `// Expand a running workflow without restarting
+const expanded = expandWorkflow(definition, newTransitions, newPlaces);
+scheduler.updateExecutor(createExecutor(expanded));
+
+// Next tick() uses the expanded definition.
+// Existing instance state (marking, context) is preserved in the database.
+// Inject tokens if the new transitions need already-satisfied prerequisites:
+await scheduler.injectToken("instance-1", "newPlace", 1);`;
+
+const workflowDefinitionType = `type WorkflowDefinition<Place, Ctx> = {
+  name: string;
+  net: WorkflowNet<Place, Ctx>;
+  guards: Map<string, GuardFn<Place, Ctx>>;
+  executors: Map<string, ExecuteFn<Place, Ctx>>;
+  initialContext: Ctx;
+  terminalPlaces: Place[];
+  invariants?: { weights: Partial<Record<Place, number>> }[];
+};`;
+
+const workflowTransitionType = `type WorkflowTransition<Place, Ctx> = Transition<Place> & {
+  type: string;
+  guard: string | null;
+  timeout?: { place: Place; ms: number };
+  config?: Record<string, unknown>;
+};`;
+
+const stepResultType = `type StepResult<Place, Ctx> =
+  | {
+      kind: "fired";
+      marking: Marking<Place>;
+      context: Ctx;
+      transition: string;
+      terminal: boolean;
+      decision?: { reasoning: string; candidates: string[] };
+    }
+  | { kind: "idle" };`;
+
+const batchStepResultType = `type BatchStepResult<Place, Ctx> =
+  | {
+      kind: "fired";
+      marking: Marking<Place>;
+      context: Ctx;
+      transitions: string[];   // all transitions that fired
+      terminal: boolean;
+    }
+  | { kind: "idle" };`;
+
+const executionResultType = `type ExecutionResult<Place, Ctx> = {
+  marking: Marking<Place>;
+  context: Ctx;
+  firedTransition: string;
+};`;
+---
+<Layout title="Engine | PetriFlow" description="Workflow engine with guards, executors, batch concurrent execution, dynamic net expansion, and SQLite persistence.">
+  <Nav currentPage="docs" />
+
+  <div class="doc-wrapper">
+    <div class="page-header">
+      <nav class="doc-breadcrumb" aria-label="Documentation navigation">
+        <a href={`${base}docs/`}>Docs</a>
+        <span aria-hidden="true">/</span>
+        <span>Engine</span>
+        <span class="doc-breadcrumb-sep" aria-hidden="true"></span>
+        <a href={`${base}docs/gate/`}>Gate</a>
+        <a href={`${base}docs/rules/`}>Rules</a>
+        <a href={`${base}docs/vercel-ai/`}>Vercel AI</a>
+      </nav>
+      <h1>Engine</h1>
+      <p>Workflow execution engine built on <a href="https://www.npmjs.com/package/petri-ts" style="color:var(--accent-text)">petri-ts</a>. Adds guards, executors, timeouts, batch concurrent execution, dynamic net expansion, and SQLite persistence to the core Petri net primitives.</p>
+      <InstallBar packages="@petriflow/engine" />
+    </div>
+
+    <aside class="doc-sidebar" aria-label="Page navigation">
+      <nav class="doc-nav">
+        <a href="#defining-a-workflow">Defining a workflow</a>
+        <a href="#guards">Guards</a>
+        <a href="#executor">Executor</a>
+        <a href="#batch-execution">Batch execution</a>
+        <a href="#scheduler">Scheduler</a>
+        <a href="#dynamic-expansion">Dynamic expansion</a>
+        <a href="#injecting-tokens">Injecting tokens</a>
+        <a href="#api-reference">API reference</a>
+      </nav>
+    </aside>
+
+    <main id="main-content">
+
+    <!-- Defining a workflow -->
+    <div class="doc-section" id="defining-a-workflow">
+      <h2>Defining a workflow</h2>
+      <p><code>defineWorkflow</code> takes places, transitions, initial marking, context, and terminal places. It validates all place references, compiles guard expressions, and extracts executor functions into separate maps.</p>
+      <Code code={defineWorkflowExample} lang="typescript" />
+      <p>Transitions are <code>WorkflowTransition</code> objects — an intersection with petri-ts <code>Transition</code>, so they pass directly to all petri-ts analysis functions (<code>reachableStates</code>, <code>isDeadlockFree</code>, <code>toDot</code>, etc.) via <code>toNet()</code>.</p>
+    </div>
+
+    <!-- Guards -->
+    <div class="doc-section" id="guards">
+      <h2>Guards</h2>
+      <p>Guards are expression strings evaluated against the workflow context. A transition is only enabled if it's structurally enabled (input places have tokens) <strong>and</strong> its guard passes. Guards are compiled at definition time via <a href="https://www.npmjs.com/package/filtrex" style="color:var(--accent-text)">filtrex</a>.</p>
+      <Code code={guardExample} lang="typescript" />
+      <p>Set <code>guard: null</code> for transitions with no guard condition. The marking is accessible inside guards via <code>marking.placeName</code>.</p>
+    </div>
+
+    <!-- Executor -->
+    <div class="doc-section" id="executor">
+      <h2>Executor</h2>
+      <p><code>createExecutor</code> wraps a <code>WorkflowDefinition</code> into a <code>WorkflowExecutor</code> with a <code>step()</code> method. Each step finds enabled transitions, picks one, fires it (consuming input tokens, producing output tokens), and runs the executor function.</p>
+      <Code code={executorExample} lang="typescript" />
+
+      <Trace label="// step() fires one transition per call" steps={[
+        { icon: "ok", html: `step() finds <strong>test</strong> enabled<br><span class="ok-text">FIRED</span> idle&rarr;tested, context updated` },
+        { icon: "ok", html: `step() finds <strong>stage</strong> enabled<br><span class="ok-text">FIRED</span> tested&rarr;staged` },
+        { icon: "wait", html: `step() finds <strong>deploy</strong> structurally enabled but guard fails<br><span class="blocked-text">IDLE</span> approved == false` },
+      ]} />
+
+      <p>When multiple transitions are enabled and no <code>decisionProvider</code> is configured, the first enabled transition fires. A decision provider can choose between candidates at runtime — useful for LLM-driven workflows.</p>
+    </div>
+
+    <!-- Batch execution -->
+    <div class="doc-section" id="batch-execution">
+      <h2>Batch execution</h2>
+      <p><code>stepBatch()</code> fires multiple independent transitions concurrently. It finds all enabled transitions, selects up to <code>maxConcurrent</code> non-conflicting ones, runs their executors in parallel via <code>Promise.all</code>, and returns the combined result.</p>
+      <Code code={stepBatchExample} lang="typescript" />
+
+      <h3>Conflict resolution</h3>
+      <p>Transitions that compete for the same input tokens cannot both fire. <code>stepBatch</code> selects greedily: it walks enabled transitions in order, consuming tokens from a working marking. If a transition's inputs are no longer available (already consumed by an earlier selection), it's skipped.</p>
+      <Code code={batchConflictExample} lang="typescript" />
+
+      <h3>Context merge</h3>
+      <p>Each executor runs independently against the original context and returns a partial patch. Patches are merged in transition-name order (alphabetical) for deterministic results. Later patches overwrite earlier ones on shared keys.</p>
+      <Code code={batchMergeExample} lang="typescript" />
+
+      <Trace label="// stepBatch fires independent transitions in parallel" steps={[
+        { icon: "ok", html: `Two independent branches: <strong>do_a</strong> (a_ready&rarr;a_done) and <strong>do_b</strong> (b_ready&rarr;b_done)<br><span class="ok-text">BOTH FIRE</span> in parallel via Promise.all` },
+        { icon: "blocked", html: `Two competing transitions: <strong>take_a</strong> and <strong>take_b</strong> both need shared:1<br><span class="blocked-text">CONFLICT</span> only take_a fires (first-enabled wins)` },
+      ]} />
+    </div>
+
+    <!-- Scheduler -->
+    <div class="doc-section" id="scheduler">
+      <h2>Scheduler</h2>
+      <p>The <code>Scheduler</code> drives workflow instances to completion. It manages persistence (SQLite), timeouts, and event callbacks. Call <code>tick()</code> manually or use <code>start()</code> for automatic polling.</p>
+      <Code code={schedulerExample} lang="typescript" />
+      <p>Pass <code>{"{ maxConcurrent }"}</code> to <code>tick()</code> to use batch execution. When set, the scheduler fires up to that many independent transitions per instance per tick. Without the option, behavior is sequential — one transition per tick, same as before.</p>
+    </div>
+
+    <!-- Dynamic expansion -->
+    <div class="doc-section" id="dynamic-expansion">
+      <h2>Dynamic expansion</h2>
+      <p><code>expandWorkflow</code> adds new transitions and places to an existing <code>WorkflowDefinition</code>. It returns a new definition — the original is not mutated. The expanded definition goes through the same validation as <code>defineWorkflow</code>: place references are checked, guards are compiled, and executors are extracted.</p>
+      <Code code={expandExample} lang="typescript" />
+
+      <h3>New places and terminal states</h3>
+      <p>Pass new places as the third argument and new terminal places in the options. Existing transitions and executors are preserved exactly.</p>
+      <Code code={expandNewPlacesExample} lang="typescript" />
+
+      <h3>Updating a running scheduler</h3>
+      <p>Use <code>updateExecutor()</code> to swap the scheduler's executor at runtime. The next <code>tick()</code> picks up the expanded definition. Instance state (marking, context) in the database is untouched.</p>
+      <Code code={updateExecutorExample} lang="typescript" />
+    </div>
+
+    <!-- Injecting tokens -->
+    <div class="doc-section" id="injecting-tokens">
+      <h2>Injecting tokens</h2>
+      <p><code>injectTokens</code> returns a new marking with additional tokens in a given place. This is essential when expanding a net where some prerequisites are already satisfied — new transitions may need tokens that represent completed work.</p>
+      <Code code={injectTokensExample} lang="typescript" />
+      <p>Both the standalone <code>injectTokens()</code> function and the scheduler's <code>injectToken()</code> method are available. The standalone function is pure (returns a new marking). The scheduler method persists the change and reactivates the instance.</p>
+    </div>
+
+    <!-- API reference -->
+    <div class="doc-section" id="api-reference">
+      <h2>API reference</h2>
+
+      <h3><code>defineWorkflow(def, options?)</code></h3>
+      <p>Creates a <code>WorkflowDefinition</code>. Validates place references, compiles guards, extracts executors. Throws on invalid references.</p>
+
+      <h3><code>expandWorkflow(definition, newTransitions, newPlaces?, options?)</code></h3>
+      <p>Returns a new <code>WorkflowDefinition</code> with additional transitions and places. Pure function — does not mutate the original. Same validation as <code>defineWorkflow</code>.</p>
+      <ul>
+        <li><strong style="color:var(--text-secondary)">definition</strong>: the existing <code>WorkflowDefinition</code> to expand</li>
+        <li><strong style="color:var(--text-secondary)">newTransitions</strong>: transitions to add (same format as <code>defineWorkflow</code>)</li>
+        <li><strong style="color:var(--text-secondary)">newPlaces</strong>: optional array of new place names</li>
+        <li><strong style="color:var(--text-secondary)">options.terminalPlaces</strong>: optional new terminal places to add</li>
+        <li><strong style="color:var(--text-secondary)">options.nodes</strong>: optional custom node executor registry</li>
+      </ul>
+
+      <h3><code>injectTokens(marking, place, count?)</code></h3>
+      <p>Returns a new marking with <code>count</code> (default 1) tokens added to <code>place</code>. Pure function.</p>
+
+      <h3><code>createExecutor(definition, options?)</code></h3>
+      <p>Creates a <code>WorkflowExecutor</code> from a definition. Optionally accepts a <code>decisionProvider</code> for choosing between multiple enabled transitions.</p>
+
+      <h3><code>WorkflowExecutor</code></h3>
+      <ul>
+        <li><strong style="color:var(--text-secondary)">step(instanceId, marking, ctx)</strong>: fire one enabled transition. Returns <code>StepResult</code>.</li>
+        <li><strong style="color:var(--text-secondary)">stepBatch(instanceId, marking, ctx, maxConcurrent)</strong>: fire up to <code>maxConcurrent</code> non-conflicting transitions in parallel. Returns <code>BatchStepResult</code>.</li>
+        <li><strong style="color:var(--text-secondary)">getTimeoutCandidates(marking)</strong>: returns transitions with timeouts that are currently enabled.</li>
+      </ul>
+
+      <h3><code>Scheduler</code></h3>
+      <ul>
+        <li><strong style="color:var(--text-secondary)">createInstance(id)</strong>: create a new workflow instance with the initial marking and context.</li>
+        <li><strong style="color:var(--text-secondary)">tick(options?)</strong>: process all active instances. Pass <code>{"{ maxConcurrent }"}</code> for batch execution. Returns total transitions fired.</li>
+        <li><strong style="color:var(--text-secondary)">injectToken(id, place, count?)</strong>: add tokens to a running instance and reactivate it.</li>
+        <li><strong style="color:var(--text-secondary)">updateExecutor(executor)</strong>: swap the executor for an expanded definition. Takes effect on next tick.</li>
+        <li><strong style="color:var(--text-secondary)">start() / stop()</strong>: automatic polling at <code>pollIntervalMs</code> (default 1000ms).</li>
+        <li><strong style="color:var(--text-secondary)">inspect(id)</strong>: read current instance state (marking, context, status).</li>
+        <li><strong style="color:var(--text-secondary)">getHistory(id)</strong>: full transition history with before/after markings.</li>
+      </ul>
+
+      <h3><code>WorkflowDefinition&lt;Place, Ctx&gt;</code></h3>
+      <Code code={workflowDefinitionType} lang="typescript" />
+
+      <h3><code>WorkflowTransition&lt;Place, Ctx&gt;</code></h3>
+      <Code code={workflowTransitionType} lang="typescript" />
+      <ul>
+        <li><strong style="color:var(--text-secondary)">type</strong>: free-form string (e.g. <code>"automatic"</code>, <code>"manual"</code>, <code>"http"</code>, <code>"timer"</code>). Used by the node registry to resolve executors from config.</li>
+        <li><strong style="color:var(--text-secondary)">guard</strong>: expression string or <code>null</code>. Compiled to a function at definition time.</li>
+        <li><strong style="color:var(--text-secondary)">timeout</strong>: optional. When the transition is enabled, a timeout token is placed after <code>ms</code> milliseconds.</li>
+        <li><strong style="color:var(--text-secondary)">config</strong>: optional. Passed to the node executor for type-based execution (e.g. HTTP config).</li>
+      </ul>
+
+      <h3><code>StepResult&lt;Place, Ctx&gt;</code></h3>
+      <Code code={stepResultType} lang="typescript" />
+
+      <h3><code>BatchStepResult&lt;Place, Ctx&gt;</code></h3>
+      <Code code={batchStepResultType} lang="typescript" />
+
+      <h3><code>ExecutionResult&lt;Place, Ctx&gt;</code></h3>
+      <Code code={executionResultType} lang="typescript" />
+
+      <h3>Utility functions</h3>
+      <ul>
+        <li><code>canFireWorkflow(marking, transition, ctx, guards?)</code> — structural + guard check</li>
+        <li><code>enabledWorkflowTransitions(net, marking, ctx, guards?)</code> — all fireable transitions</li>
+        <li><code>fireWorkflow(marking, transition, ctx, guards?, executors?)</code> — fire and execute</li>
+        <li><code>toNet(workflowNet)</code> — strip extensions for petri-ts analysis</li>
+        <li><code>analyse(definition, options?)</code> — reachable states, deadlock detection, invariant checking</li>
+        <li><code>compileGuard(expr)</code> — compile a guard expression string to a function</li>
+        <li><code>sqliteAdapter(db, workflowName)</code> — SQLite persistence adapter</li>
+      </ul>
+    </div>
+    </main>
+  </div>
+
+  <Footer variant="minimal" />
+</Layout>

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -66,6 +66,12 @@ const base = import.meta.env.BASE_URL;
         <p>DSL reference, composition model, and internals. Learn how to write safety rules and how they compile to verified Petri nets.</p>
         <span class="doc-card-link">Read docs &rarr;</span>
       </a>
+      <a href={`${base}docs/engine/`} class="doc-card">
+        <div class="doc-card-label">@petriflow/engine</div>
+        <h2>Engine</h2>
+        <p>Workflow execution engine. Guards, executors, batch concurrent execution, dynamic net expansion, and SQLite persistence.</p>
+        <span class="doc-card-link">Read docs &rarr;</span>
+      </a>
       <a href={`${base}docs/gate/`} class="doc-card">
         <div class="doc-card-label">@petriflow/gate</div>
         <h2>Gate</h2>


### PR DESCRIPTION
## Summary

- **Batch concurrent execution**: `stepBatch()` on the executor fires multiple independent transitions concurrently via `Promise.all`. Greedy conflict resolution ensures competing transitions don't double-fire. Context patches merge in transition-name order for deterministic results. `Scheduler.tick({ maxConcurrent })` opts into batch mode; default behavior unchanged.
- **Dynamic net expansion**: `expandWorkflow()` returns a new `WorkflowDefinition` with additional transitions and places — pure, same validation as `defineWorkflow()`. `injectTokens()` helper for placing tokens into new/existing places. `Scheduler.updateExecutor()` swaps the executor at runtime so expanded definitions take effect on the next tick.
- **Engine docs page**: New `/docs/engine/` page covering the full engine API (defineWorkflow, guards, executor, batch execution, scheduler, dynamic expansion, token injection, API reference). Added to docs index.
- **Version bump**: `@petriflow/engine` 0.2.0 → 0.3.0

### New exports
- `expandWorkflow`, `injectTokens`, `BatchStepResult`
- `Scheduler.updateExecutor()`, `Scheduler.tick({ maxConcurrent })`
- `WorkflowExecutor.stepBatch()`

### Tests (20 new, 0 broken)
- **batch.test.ts** (8): independent concurrent fire, conflict resolution, merge ordering, maxConcurrent=1 equivalence, limit enforcement, scheduler integration
- **expand.test.ts** (12): wiring, guard compilation, immutability, validation errors, end-to-end with executor, injectTokens, scheduler updateExecutor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch concurrent execution with configurable concurrency limits for efficient workflow transition processing
  * Dynamic workflow expansion to add transitions and places after initial definition
  * Token injection capability for runtime marking modifications
  * Scheduler now supports concurrent execution mode and executor updates

* **Documentation**
  * New Engine documentation page with comprehensive API reference and usage examples

* **Chores**
  * Package version bumped to 0.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->